### PR TITLE
Devel

### DIFF
--- a/cmake/ToolchainOptions.cmake
+++ b/cmake/ToolchainOptions.cmake
@@ -19,7 +19,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGXX)
 	# Release build with debug symbols
 	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -O3")
 	# Debug Build
-	set(CMAKE_CXX_FLAGS_DEBUG "-Og")
+	set(CMAKE_CXX_FLAGS_DEBUG "-g")
 	# Release build optimized for size
 	set(CMAKE_CXX_FLAGS_MINSIZEREL "-Os")
 

--- a/include/adouble.h
+++ b/include/adouble.h
@@ -193,7 +193,7 @@ public:
 
   }
 
-  inline const double& value() const {
+  inline double value() const {
     return a;
   }
 
@@ -201,7 +201,7 @@ public:
     return a;
   }
 
-  inline const double& getValue() const {
+  inline double getValue() const {
     return a;
   }
 

--- a/test/include/TestUtil.h
+++ b/test/include/TestUtil.h
@@ -17,23 +17,24 @@
 
 namespace {
 template <typename T>
-auto v_impl(T t, std::false_type) -> decltype(t) {
+auto v_impl(const T t, std::false_type) -> decltype(t) {
   return t;
 }
 template <typename T>
-auto v_impl(T t, std::true_type) -> decltype(t.value()) {
-  return t.value();
+auto v_impl(const T t, std::true_type) -> decltype(t.value()) {
+  auto val = t.value();
+  return val;
 }
 template <typename T>
-auto val(T t) -> decltype(v_impl(t, std::is_class<T>())) {
+auto val(const T t) -> decltype(v_impl(t, std::is_class<T>())) {
   return v_impl(t, std::is_class<T>());
 }
 }
 
 #define _test_2_t(OP, EXPECTED) \
 WHEN("a" T_STRINGIFY(OP) "b") { \
-  const auto ad = a.value(); \
-  const auto bd = b.value(); \
+  const auto ad = val(a); \
+  const auto bd = val(b); \
   auto c = a OP b; \
   THEN("a new value is created") { \
     auto cr = val(c); \
@@ -42,20 +43,21 @@ WHEN("a" T_STRINGIFY(OP) "b") { \
     else \
 	REQUIRE(EXPECTED == Approx(cr)); \
     AND_THEN("The old values are unchanged") { \
-	REQUIRE(a.value() == ad); \
-	REQUIRE(b.value() == bd); \
+	REQUIRE(val(a) == ad); \
+	REQUIRE(val(b) == bd); \
     } \
   } \
 }
 
 #define _test_1_t(OP, EXPECTED) \
 WHEN("a" T_STRINGIFY(OP) "=b") { \
-  const auto bd = b.value(); \
+  const auto bd = val(b); \
   a OP##= b; \
   THEN("a is changed") { \
-    REQUIRE(a.value() == Approx(EXPECTED)); \
+    auto ad = val(a); \
+    REQUIRE(ad == Approx(EXPECTED)); \
     AND_THEN("b is unchanged") { \
-	REQUIRE(b.value() == bd); \
+	REQUIRE(val(b) == bd); \
     } \
   } \
 }

--- a/test/include/TestUtil.h
+++ b/test/include/TestUtil.h
@@ -9,19 +9,24 @@
 #define TESTUTIL_H_
 
 #include <type_traits>
+#include <iostream>
 
 #define T_STRINGIFY_(A) # A
 #define T_STRINGIFY__(A) T_STRINGIFY_(A)
 #define T_STRINGIFY(A) T_STRINGIFY__(A)
 
 namespace {
-template<typename U>
-inline auto val(U&& val) -> decltype(val.value()) {
-  return val.value();
+template <typename T>
+auto v_impl(T t, std::false_type) -> decltype(t) {
+  return t;
 }
-
-inline bool val(bool val) {
-  return val;
+template <typename T>
+auto v_impl(T t, std::true_type) -> decltype(t.value()) {
+  return t.value();
+}
+template <typename T>
+auto val(T t) -> decltype(v_impl(t, std::is_class<T>())) {
+  return v_impl(t, std::is_class<T>());
 }
 }
 


### PR DESCRIPTION
# Changes
- const adouble returns value instead of reference
- TestUtil flexible value extraction
